### PR TITLE
Additional game msg file reading (#2)

### DIFF
--- a/sfall/HeroAppearance.cpp
+++ b/sfall/HeroAppearance.cpp
@@ -23,6 +23,7 @@
 #include "FalloutEngine.h"
 #include "HeroAppearance.h"
 #include "ScriptExtender.h"
+#include "Message.h"
 
 bool AppModEnabled=false; //check if Appearance mod enabled for script fuctions
 
@@ -63,35 +64,6 @@ typedef struct LINENode {
 		offset=0;
 	}
 } LINENode;
-
-
-//for holding a message
-typedef struct MSGNode {
-	DWORD ref;
-	DWORD a;
-	char *msg1; //unused
-	char *msg2;
-
-	MSGNode() {
-		ref=0;
-		a=0;
-		msg1=NULL;
-		msg2=NULL;
-	}
-} MSGNode;
-
-
-//for holding msg array
-typedef struct MSGList {
-	long numMsgs;
-	void *MsgNodes;
-
-	MSGList() {
-		MsgNodes=NULL;
-		numMsgs=0;
-	}
-} MSGList;
-
 
 
 //structures for holding frms loaded with fallout2 functions
@@ -331,93 +303,6 @@ int FWriteDword(void *FileStream, DWORD bVal) {
 	}
 	return retVal;
 }
-
-
-/////////////////////////////////////////////////////////////////MESSAGE FUNCTIONS////////////////////////////////////////////////////////////////////////
-
-//--------------------------------------------------
-int LoadMsgList(MSGList *MsgList, char *MsgFilePath) {
-	int retVal;
-	__asm {
-		mov edx, MsgFilePath
-		mov eax, MsgList
-		call message_load_
-		mov retVal, eax
-	}
-	return retVal;
-}
-
-
-//-----------------------------------------
-int DestroyMsgList(MSGList *MsgList) {
-	int retVal;
-	__asm {
-		mov eax, MsgList
-		call message_exit_
-		mov retVal, eax
-	}
-	return retVal;
-}
-
-/*
-//-----------------------------------------------------------
-bool GetMsg(MSGList *MsgList, MSGNode *MsgNode, DWORD msgRef) {
-	bool retVal=FALSE;
-	MsgNode->ref=msgRef;
-
-	__asm {
-		mov edx, MsgNode
-		mov eax, MsgList
-		call message_search_
-		cmp eax, 1
-		jne EndFunc
-		mov retVal, 1
-EndFunc:
-	}
-	return retVal;
-}
-*/
-
-
-//----------------------------------------------------
-MSGNode *GetMsgNode(MSGList *MsgList, DWORD msgRef) {
-
-	if (MsgList == NULL) return NULL;
-	if (MsgList->numMsgs <= 0) return NULL;
-
-	MSGNode *MsgNode = (MSGNode*)MsgList->MsgNodes;
-
-	long last = MsgList->numMsgs - 1;
-	long first = 0;
-	long mid;
-
-	//Use Binary Search to find msg
-	while (first <= last) {
-		mid = (first + last) / 2;
-		if (msgRef > MsgNode[mid].ref)
-			first = mid + 1;
-		else if (msgRef < MsgNode[mid].ref)
-			last = mid - 1;
-		else
-			return &MsgNode[mid];
-	}
-
-	return NULL;
-}
-
-
-//--------------------------------------------------------
-char* GetMsg(MSGList *MsgList, DWORD msgRef, int msgNum) {
-	MSGNode *MsgNode = GetMsgNode(MsgList, msgRef);
-	if (MsgNode) {
-		if (msgNum == 2)
-			return MsgNode->msg2;
-		else if (msgNum == 1)
-			return MsgNode->msg1;
-	}
-	return NULL;
-}
-
 
 
 /////////////////////////////////////////////////////////////////MOUSE FUNCTIONS////////////////////////////////////////////////////////////////////////

--- a/sfall/LoadGameHook.cpp
+++ b/sfall/LoadGameHook.cpp
@@ -313,8 +313,7 @@ static void __declspec(naked) NewGame() {
 	}
 }
 
-static void ReadExtraGameMsgFilesIfNeeded()
-{
+static void ReadExtraGameMsgFilesIfNeeded() {
 	if (gExtraGameMsgLists.empty())
 		ReadExtraGameMsgFiles();
 }

--- a/sfall/Message.cpp
+++ b/sfall/Message.cpp
@@ -1,0 +1,95 @@
+/*
+ *    sfall
+ *    Copyright (C) 2009, 2010  Mash (Matt Wells, mashw at bigpond dot net dot au)
+ *
+ *    This program is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Message.h"
+#include "FalloutEngine.h"
+
+std::unordered_map<int, MSGList*> gExtraGameMsgLists;
+
+int LoadMsgList(MSGList *MsgList, char *MsgFilePath) {
+	int retVal;
+	__asm {
+		mov edx, MsgFilePath
+		mov eax, MsgList
+		call message_load_
+		mov retVal, eax
+	}
+	return retVal;
+}
+
+int DestroyMsgList(MSGList *MsgList) {
+	int retVal;
+	__asm {
+		mov eax, MsgList
+		call message_exit_
+		mov retVal, eax
+	}
+	return retVal;
+}
+
+//bool GetMsg(MSGList *MsgList, MSGNode *MsgNode, DWORD msgRef) {
+//	bool retVal=FALSE;
+//	MsgNode->ref=msgRef;
+//
+//	__asm {
+//	mov edx, MsgNode
+//	mov eax, MsgList
+//	call message_search_
+//	cmp eax, 1
+//	jne EndFunc
+//	mov retVal, 1
+//	EndFunc:
+//	}
+//	return retVal;
+//}
+
+MSGNode *GetMsgNode(MSGList *MsgList, DWORD msgRef) {
+
+	if (MsgList == NULL) return NULL;
+	if (MsgList->numMsgs <= 0) return NULL;
+
+	MSGNode *MsgNode = (MSGNode*)MsgList->MsgNodes;
+
+	long last = MsgList->numMsgs - 1;
+	long first = 0;
+	long mid;
+
+	//Use Binary Search to find msg
+	while (first <= last) {
+		mid = (first + last) / 2;
+		if (msgRef > MsgNode[mid].ref)
+			first = mid + 1;
+		else if (msgRef < MsgNode[mid].ref)
+			last = mid - 1;
+		else
+			return &MsgNode[mid];
+	}
+
+	return NULL;
+}
+
+char* GetMsg(MSGList *MsgList, DWORD msgRef, int msgNum) {
+	MSGNode *MsgNode = GetMsgNode(MsgList, msgRef);
+	if (MsgNode) {
+		if (msgNum == 2)
+			return MsgNode->msg2;
+		else if (msgNum == 1)
+			return MsgNode->msg1;
+	}
+	return NULL;
+}

--- a/sfall/Message.cpp
+++ b/sfall/Message.cpp
@@ -94,8 +94,7 @@ char* GetMsg(MSGList *MsgList, DWORD msgRef, int msgNum) {
 	return NULL;
 }
 
-void ReadExtraGameMsgFiles()
-{
+void ReadExtraGameMsgFiles() {
 	int read;
 	std::string names;
 
@@ -115,12 +114,10 @@ void ReadExtraGameMsgFiles()
 	int end;
 	int length;
 
-	while ((end = names.find_first_of(',', begin)) != std::string::npos)
-	{
+	while ((end = names.find_first_of(',', begin)) != std::string::npos) {
 		length = end - begin;
 
-		if (length > 0)
-		{
+		if (length > 0) {
 			std::string path = "game\\" + names.substr(begin, length) + ".msg";
 			MSGList* list = new MSGList;
 
@@ -132,4 +129,15 @@ void ReadExtraGameMsgFiles()
 
 		begin = end + 1;
 	}
+}
+
+void ClearReadExtraGameMsgFiles() {
+	std::tr1::unordered_map<int, MSGList*>::iterator it;
+
+	for (it = gExtraGameMsgLists.begin(); it != gExtraGameMsgLists.end(); ++it) {
+		DestroyMsgList(it->second);
+		delete it->second;
+	}
+
+	gExtraGameMsgLists.clear();
 }

--- a/sfall/Message.cpp
+++ b/sfall/Message.cpp
@@ -16,6 +16,7 @@
  *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <string>
 #include "Message.h"
 #include "FalloutEngine.h"
 

--- a/sfall/Message.cpp
+++ b/sfall/Message.cpp
@@ -19,7 +19,7 @@
 #include "Message.h"
 #include "FalloutEngine.h"
 
-std::unordered_map<int, MSGList*> gExtraGameMsgLists;
+std::tr1::unordered_map<int, MSGList*> gExtraGameMsgLists;
 
 int LoadMsgList(MSGList *MsgList, char *MsgFilePath) {
 	int retVal;

--- a/sfall/Message.cpp
+++ b/sfall/Message.cpp
@@ -93,3 +93,43 @@ char* GetMsg(MSGList *MsgList, DWORD msgRef, int msgNum) {
 	}
 	return NULL;
 }
+
+void ReadExtraGameMsgFiles()
+{
+	int read;
+	std::string names;
+
+	names.resize(256);
+
+	while ((read = GetPrivateProfileStringA("Misc", "ExtraGameMsgFileList", "",
+		(LPSTR)names.data(), names.size(), ".\\ddraw.ini")) == names.size() - 1)
+		names.resize(names.size() + 256);
+
+	if (names.empty())
+		return;
+
+	names.resize(names.find_first_of('\0'));
+	names.append(",");
+
+	int begin = 0;
+	int end;
+	int length;
+
+	while ((end = names.find_first_of(',', begin)) != std::string::npos)
+	{
+		length = end - begin;
+
+		if (length > 0)
+		{
+			std::string path = "game\\" + names.substr(begin, length) + ".msg";
+			MSGList* list = new MSGList;
+
+			if (LoadMsgList(list, (char*)path.data()) == 1)
+				gExtraGameMsgLists.insert(std::make_pair(0x2000 + gExtraGameMsgLists.size(), list));
+			else
+				delete list;
+		}
+
+		begin = end + 1;
+	}
+}

--- a/sfall/Message.h
+++ b/sfall/Message.h
@@ -1,0 +1,56 @@
+/*
+*    sfall
+*    Copyright (C) 2008, 2009  The sfall team
+*
+*    This program is free software: you can redistribute it and/or modify
+*    it under the terms of the GNU General Public License as published by
+*    the Free Software Foundation, either version 3 of the License, or
+*    (at your option) any later version.
+*
+*    This program is distributed in the hope that it will be useful,
+*    but WITHOUT ANY WARRANTY; without even the implied warranty of
+*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*    GNU General Public License for more details.
+*
+*    You should have received a copy of the GNU General Public License
+*    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <unordered_map>
+#include "main.h"
+
+//for holding a message
+typedef struct MSGNode {
+	DWORD ref;
+	DWORD a;
+	char *msg1; //unused
+	char *msg2;
+
+	MSGNode() {
+		ref = 0;
+		a = 0;
+		msg1 = NULL;
+		msg2 = NULL;
+	}
+} MSGNode;
+
+//for holding msg array
+typedef struct MSGList {
+	long numMsgs;
+	void *MsgNodes;
+
+	MSGList() {
+		MsgNodes = NULL;
+		numMsgs = 0;
+	}
+} MSGList;
+
+extern std::unordered_map<int, MSGList*> gExtraGameMsgLists;
+
+int LoadMsgList(MSGList *MsgList, char *MsgFilePath);
+int DestroyMsgList(MSGList *MsgList);
+//bool GetMsg(MSGList *MsgList, MSGNode *MsgNode, DWORD msgRef);
+MSGNode *GetMsgNode(MSGList *MsgList, DWORD msgRef);
+char* GetMsg(MSGList *MsgList, DWORD msgRef, int msgNum);

--- a/sfall/Message.h
+++ b/sfall/Message.h
@@ -47,7 +47,7 @@ typedef struct MSGList {
 	}
 } MSGList;
 
-extern std::unordered_map<int, MSGList*> gExtraGameMsgLists;
+extern std::tr1::unordered_map<int, MSGList*> gExtraGameMsgLists;
 
 int LoadMsgList(MSGList *MsgList, char *MsgFilePath);
 int DestroyMsgList(MSGList *MsgList);

--- a/sfall/Message.h
+++ b/sfall/Message.h
@@ -55,3 +55,4 @@ int DestroyMsgList(MSGList *MsgList);
 MSGNode *GetMsgNode(MSGList *MsgList, DWORD msgRef);
 char* GetMsg(MSGList *MsgList, DWORD msgRef, int msgNum);
 void ReadExtraGameMsgFiles();
+void ClearReadExtraGameMsgFiles();

--- a/sfall/Message.h
+++ b/sfall/Message.h
@@ -54,3 +54,4 @@ int DestroyMsgList(MSGList *MsgList);
 //bool GetMsg(MSGList *MsgList, MSGNode *MsgNode, DWORD msgRef);
 MSGNode *GetMsgNode(MSGList *MsgList, DWORD msgRef);
 char* GetMsg(MSGList *MsgList, DWORD msgRef, int msgNum);
+void ReadExtraGameMsgFiles();

--- a/sfall/ScriptOps/ScriptUtils.hpp
+++ b/sfall/ScriptOps/ScriptUtils.hpp
@@ -26,6 +26,7 @@
 #include "ScriptArrays.hpp"
 #include "FileSystem.h"
 #include "Arrays.h"
+#include "Message.h"
 
 static void __declspec(naked) funcSqrt() {
 	__asm {
@@ -869,6 +870,21 @@ static void _stdcall op_message_str_game2() {
 		}
 		else if (fileId >= 0x1000 && fileId <= 0x1005) { // proto msg files
 			msg = GetMessageStr((DWORD)&proto_msg_files[2*(fileId - 0x1000)], msgId);
+		}
+		else if (fileId >= 0x2000) // Extra game message files.
+		{
+			std::unordered_map<int, MSGList*>::iterator it
+				= gExtraGameMsgLists.find(fileId);
+
+			if (it != gExtraGameMsgLists.end())
+			{
+				msg = GetMsg(it->second, msgId, 2);
+			}
+			else
+			{
+				msg = 0;
+				SetOpReturn(0, DATATYPE_INT);
+			}
 		}
 		if (msg != 0)
 			SetOpReturn(msg);

--- a/sfall/ScriptOps/ScriptUtils.hpp
+++ b/sfall/ScriptOps/ScriptUtils.hpp
@@ -872,7 +872,7 @@ static void _stdcall op_message_str_game2() {
 			msg = GetMessageStr((DWORD)&proto_msg_files[2*(fileId - 0x1000)], msgId);
 		}
 		else if (fileId >= 0x2000) { // Extra game message files.
-			std::unordered_map<int, MSGList*>::iterator it = gExtraGameMsgLists.find(fileId);
+			std::tr1::unordered_map<int, MSGList*>::iterator it = gExtraGameMsgLists.find(fileId);
 
 			if (it != gExtraGameMsgLists.end())
 				msg = GetMsg(it->second, msgId, 2);

--- a/sfall/ScriptOps/ScriptUtils.hpp
+++ b/sfall/ScriptOps/ScriptUtils.hpp
@@ -871,20 +871,13 @@ static void _stdcall op_message_str_game2() {
 		else if (fileId >= 0x1000 && fileId <= 0x1005) { // proto msg files
 			msg = GetMessageStr((DWORD)&proto_msg_files[2*(fileId - 0x1000)], msgId);
 		}
-		else if (fileId >= 0x2000) // Extra game message files.
-		{
-			std::unordered_map<int, MSGList*>::iterator it
-				= gExtraGameMsgLists.find(fileId);
+		else if (fileId >= 0x2000) { // Extra game message files.
+			std::unordered_map<int, MSGList*>::iterator it = gExtraGameMsgLists.find(fileId);
 
 			if (it != gExtraGameMsgLists.end())
-			{
 				msg = GetMsg(it->second, msgId, 2);
-			}
 			else
-			{
 				msg = 0;
-				SetOpReturn(0, DATATYPE_INT);
-			}
 		}
 		if (msg != 0)
 			SetOpReturn(msg);

--- a/sfall/ScriptOps/ScriptUtils.hpp
+++ b/sfall/ScriptOps/ScriptUtils.hpp
@@ -862,9 +862,10 @@ static const DWORD* proto_msg_files = (DWORD*)0x006647AC;
 
 static void _stdcall op_message_str_game2() {
 	DWORD fileId = opArgs[0];
+	const char* msg = 0;
+
 	if (IsOpArgInt(0) && IsOpArgInt(1)) {
 		int msgId = GetOpArgInt(1);
-		const char* msg;
 		if (fileId < 20) { // main msg files
 			msg = GetMessageStr(game_msg_files[fileId], msgId);
 		}
@@ -876,16 +877,13 @@ static void _stdcall op_message_str_game2() {
 
 			if (it != gExtraGameMsgLists.end())
 				msg = GetMsg(it->second, msgId, 2);
-			else
-				msg = 0;
 		}
-		if (msg != 0)
-			SetOpReturn(msg);
-		else
-			SetOpReturn(0, DATATYPE_INT);
-	} else {
-		SetOpReturn(0, DATATYPE_INT);
 	}
+	
+	if (msg == 0)
+		msg = "Error";
+
+	SetOpReturn(msg);
 }
 
 static void __declspec(naked) op_message_str_game() {

--- a/sfall/main.cpp
+++ b/sfall/main.cpp
@@ -1545,7 +1545,7 @@ static void DllMain2() {
 
 void ClearExtraGameMsgFiles()
 {
-	std::unordered_map<int, MSGList*>::iterator it;
+	std::tr1::unordered_map<int, MSGList*>::iterator it;
 
 	for (it = gExtraGameMsgLists.begin(); it != gExtraGameMsgLists.end(); ++it)
 	{

--- a/sfall/main.cpp
+++ b/sfall/main.cpp
@@ -1543,19 +1543,8 @@ static void DllMain2() {
 	dlogr("Leave DllMain2", DL_MAIN);  
 }
 
-void ClearExtraGameMsgFiles()
-{
-	std::tr1::unordered_map<int, MSGList*>::iterator it;
-
-	for (it = gExtraGameMsgLists.begin(); it != gExtraGameMsgLists.end(); ++it)
-	{
-		DestroyMsgList(it->second);
-		delete it->second;
-	}
-}
-
 static void _stdcall OnExit() {
-	ClearExtraGameMsgFiles();
+	ClearReadExtraGameMsgFiles();
 	ConsoleExit();
 	AnimationsAtOnceExit();
 	HeroAppearanceModExit();

--- a/sfall/main.cpp
+++ b/sfall/main.cpp
@@ -59,6 +59,7 @@
 #include "Tiles.h"
 #include "timer.h"
 #include "version.h"
+#include "Message.h"
 
 bool IsDebug = false;
 
@@ -1542,7 +1543,19 @@ static void DllMain2() {
 	dlogr("Leave DllMain2", DL_MAIN);  
 }
 
+void ClearExtraGameMsgFiles()
+{
+	std::unordered_map<int, MSGList*>::iterator it;
+
+	for (it = gExtraGameMsgLists.begin(); it != gExtraGameMsgLists.end(); ++it)
+	{
+		DestroyMsgList(it->second);
+		delete it->second;
+	}
+}
+
 static void _stdcall OnExit() {
+	ClearExtraGameMsgFiles();
 	ConsoleExit();
 	AnimationsAtOnceExit();
 	HeroAppearanceModExit();


### PR DESCRIPTION
This is the second approach on adding the possibility to read more game msg files than the hardcoded ones.

Previous pull request is #41.

Among other changes - like fixing a potential memory leak in **ReadExtraGameMsgFiles** - this time file reading is done from the **MainMenu** function which is called after main menu initialization.

There's one special place in the **MainMenu** function. At first I added a **ReadExtraGameMsgFiles** call before the **__asm** block, but that triggered an assertion when dereferencing iterators of the **gExtraGameMsgLists** map. Turns out the call has to be made between the **pushad** and **popad** ops, otherwise it corrupts the map somehow if the **MainMenu** function is called more than once. This happened only in the debug mode.

NovaRain's suggestions and findings from the previous pull request regarding the tr1 and headers are included.