### PR TITLE
Early sfall save game loading

### DIFF
--- a/sfall/Modules/LoadGameHook.cpp
+++ b/sfall/Modules/LoadGameHook.cpp
@@ -157,9 +157,7 @@ end:
 // should be called before savegame is loaded
 static void _stdcall LoadGame2_Before() {
 	ResetState(1);
-}
-
-static void _stdcall LoadGame2_After() {
+	
 	char buf[MAX_PATH];
 	GetSavePath(buf, "gv");
 
@@ -179,7 +177,9 @@ static void _stdcall LoadGame2_After() {
 	} else {
 		dlogr("Cannot read sfallgv.sav - assuming non-sfall save.", DL_MAIN);
 	}
+}
 
+static void _stdcall LoadGame2_After() {
 	LoadGlobalScripts();
 	CritLoad();
 	LoadHeroAppearance();


### PR DESCRIPTION
While working on a script which makes extensive use of saved arrays I noticed that they are not available for the script in the `start` function when the game loads. The reason being that the `start` script function is called right after the game loads a save state which is before `LoadGame2_After` call where arrays are currently read.

One way to bypass this is to add a timed event with 1 tick delay in `start` and use arrays in the `timed_event_p_proc` script function instead. As you can imagine, it's a rather clunky way to do this, so I modified sfall to make saved arrays available in the `start` script function.

At first I wrote code that skipped other data in the sfall save game file and read only arrays in `LoadGame2_Before` while leaving reading the rest in `LoadGame2_Before`, but it seems that moving all the reading to `LoadGame2_Before` doesn't break anything.
