### PR TITLE
Crafty Anim Combat Fix & Dead Critter highlight feature

### DIFF
--- a/sfall/AnimationsAtOnceLimit.h
+++ b/sfall/AnimationsAtOnceLimit.h
@@ -20,7 +20,7 @@
 #pragma once
 
 
-void AnimationsAtOnceInit(signed char aniMax);
+void AnimationsAtOnceInit(); //signed char aniMax
 void AnimationsAtOnceExit();
 
 

--- a/sfall/FalloutEngine.cpp
+++ b/sfall/FalloutEngine.cpp
@@ -263,6 +263,7 @@ const DWORD credits_ = 0x42C860;
 const DWORD credits_get_next_line_ = 0x42CE6C;
 const DWORD critter_body_type_ = 0x42DDC4;
 const DWORD critter_can_obj_dude_rest_ = 0x42E564;
+const DWORD critter_flag_check_ = 0x42E6AC;
 const DWORD critter_compute_ap_from_distance_ = 0x42E62C;
 const DWORD critter_get_hits_ = 0x42D18C;
 const DWORD critter_is_dead_ = 0x42DD18;

--- a/sfall/FalloutEngine.cpp
+++ b/sfall/FalloutEngine.cpp
@@ -250,6 +250,7 @@ const DWORD check_death_ = 0x410814;
 const DWORD Check4Keys_ = 0x43F73C;
 const DWORD combat_ = 0x422D2C;
 const DWORD combat_ai_ = 0x42B130;
+const DWORD combat_anim_finished_ = 0x425E80;
 const DWORD combat_attack_ = 0x422F3C;
 const DWORD combat_input_ = 0x4227F4;
 const DWORD combat_should_end_ = 0x422C60;

--- a/sfall/FalloutEngine.h
+++ b/sfall/FalloutEngine.h
@@ -436,6 +436,7 @@ extern const DWORD credits_;
 extern const DWORD credits_get_next_line_;
 extern const DWORD critter_body_type_;
 extern const DWORD critter_can_obj_dude_rest_;
+extern const DWORD critter_flag_check_;
 extern const DWORD critter_compute_ap_from_distance_;
 extern const DWORD critter_get_hits_;
 extern const DWORD critter_is_dead_; // eax - critter

--- a/sfall/FalloutEngine.h
+++ b/sfall/FalloutEngine.h
@@ -31,6 +31,7 @@
 
 #define _aiInfoList                 0x510948
 #define _ambient_light              0x51923C
+#define _anim_set                   0x54CC14
 #define _art                        0x510738
 #define _art_name                   0x56C9E4
 #define _art_vault_guy_num          0x5108A4
@@ -422,6 +423,7 @@ extern const DWORD check_death_;
 extern const DWORD Check4Keys_;
 extern const DWORD combat_;
 extern const DWORD combat_ai_;
+extern const DWORD combat_anim_finished_;
 extern const DWORD combat_attack_;
 extern const DWORD combat_input_;
 extern const DWORD combat_should_end_;

--- a/sfall/main.cpp
+++ b/sfall/main.cpp
@@ -1454,12 +1454,13 @@ static void DllMain2() {
 	dlogr("Patching out ereg call.", DL_INIT);
 	BlockCall(0x4425E6);
 
-	tmp = GetPrivateProfileIntA("Misc", "AnimationsAtOnceLimit", 32, ini);
-	if ((signed char)tmp > 32) {
-		dlog("Applying AnimationsAtOnceLimit patch.", DL_INIT);
-		AnimationsAtOnceInit((signed char)tmp);
-		dlogr(" Done", DL_INIT);
-	}
+	AnimationsAtOnceInit();
+	//tmp = GetPrivateProfileIntA("Misc", "AnimationsAtOnceLimit", 32, ini);
+	//if ((signed char)tmp > 32) {
+	//	dlog("Applying AnimationsAtOnceLimit patch.", DL_INIT);
+	//	AnimationsAtOnceInit((signed char)tmp);
+	//	dlogr(" Done", DL_INIT);
+	//} 
 
 	if (GetPrivateProfileIntA("Misc", "RemoveCriticalTimelimits", 0, ini)) {
 		dlog("Removing critical time limits.", DL_INIT);


### PR DESCRIPTION
К функции подсветки контейнеров добавлена подсветка мертвых криттеров.
В добавление изменена механика функции подсветки, теперь не подсвечиваются предметы у которых установлен флаг NoHighlight_  и исключен Pid багажника из подсветки контейнеров.

Об анимации писал на форуме NMA - неохота повторятся.

Translate:
Highlight of dead critters is added to the function of container outline highlight.
In addition, changed the mechanics of highlight function, now do not highlight the items whose flag is set NoHighlight_ And exclude the Pid of the trunk of highlight of the containers.
