### PR TITLE
Correcting bug for negative values SPECIAL parameters.

### DIFF
--- a/sfall/FalloutEngine.cpp
+++ b/sfall/FalloutEngine.cpp
@@ -343,6 +343,7 @@ const DWORD gsnd_build_weapon_sfx_name_ = 0x451760;
 const DWORD gsound_play_sfx_file_ = 0x4519A8;
 const DWORD handle_inventory_ = 0x46E7B0;
 const DWORD inc_game_time_ = 0x4A34CC;
+const DWORD inc_stat_ = 0x4AF5D4;
 const DWORD insert_withdrawal_ = 0x47A290;
 const DWORD interpret_ = 0x46CCA4;
 const DWORD interpretAddString_ = 0x467A80; // edx = ptr to string, eax = script

--- a/sfall/FalloutEngine.h
+++ b/sfall/FalloutEngine.h
@@ -41,6 +41,7 @@
 #define _btable                     0x59E944
 #define _btncnt                     0x43EA1C
 #define _CarCurrArea                0x672E68
+#define _character_points           0x518538
 #define _cmap                       0x51DF34
 #define _colorTable                 0x6A38D0
 #define _combat_free_move           0x56D39C
@@ -514,6 +515,7 @@ extern const DWORD gsnd_build_weapon_sfx_name_;
 extern const DWORD gsound_play_sfx_file_;
 extern const DWORD handle_inventory_;
 extern const DWORD inc_game_time_;
+extern const DWORD inc_stat_;
 extern const DWORD insert_withdrawal_;
 extern const DWORD interpret_; // <eax> - programPtr, <edx> - ??? (-1)
 extern const DWORD interpretAddString_;


### PR DESCRIPTION
Correcting the incorrect behavior of the SPECIAL value counter when creating a character.
An error occurs when Trait with negative effects affects the SPECIAL parameters of the player.

Update:
I was thinking maybe there should be a condition to put?
in the original game, no Trait with a negative parameter to the SPECIAL
extra edits don't need when not connected file perks.ini.