### PR TITLE
Procedure handlers combat_is_starting_p_proc/combat_is_over_p_proc. (Crafty)

### DIFF
--- a/sfall/Define.h
+++ b/sfall/Define.h
@@ -274,3 +274,9 @@
 #define ROLL_FAILURE          (1)
 #define ROLL_SUCCESS          (2)
 #define ROLL_CRITICAL_SUCCESS (3)
+
+//XXXXXXXXXXXXXXXXXXXXXX
+//XX Handlers defines XX
+//XXXXXXXXXXXXXXXXXXXXXX
+#define combat_is_starting_p_proc (26)
+#define combat_is_over_p_proc     (27)


### PR DESCRIPTION
combat_is_starting_p_proc - It is called when the data is initialized, but it does not mean that the critter is in combat.
combat_is_over_p_proc - Called before the end of the combat.