### PR TITLE
Scripting function "set_ini_setting" for FuncX  [sfall v3.8]

### DIFF
--- a/sfall/ScriptExtender.cpp
+++ b/sfall/ScriptExtender.cpp
@@ -374,6 +374,7 @@ static const SfallOpcodeMetadata opcodeMetaArray[] = {
 	{sf_test, "validate_test", {DATATYPE_MASK_INT, DATATYPE_MASK_INT | DATATYPE_MASK_FLOAT, DATATYPE_MASK_STR, DATATYPE_NONE}},
 	{sf_spatial_radius, "spatial_radius", {DATATYPE_MASK_VALID_OBJ}},
 	{sf_critter_inven_obj2, "critter_inven_obj2", {DATATYPE_MASK_VALID_OBJ, DATATYPE_MASK_INT}},
+	{sf_set_ini_setting, "set_ini_setting", {DATATYPE_MASK_STR, DATATYPE_MASK_INT | DATATYPE_MASK_STR}},
 	//{op_message_str_game, {}}
 };
 

--- a/sfall/ScriptOps/MetaruleOp.hpp
+++ b/sfall/ScriptOps/MetaruleOp.hpp
@@ -112,6 +112,7 @@ static const SfallMetarule metaruleArray[] = {
 	{"intface_hide", sf_intface_hide, 0, 0},
 	{"intface_is_hidden", sf_intface_is_hidden, 0, 0},
 	{"exec_map_update_scripts", sf_exec_map_update_scripts, 0, 0},
+	{"set_ini_setting", sf_set_ini_setting, 2, 2},
 };
 
 static void InitMetaruleTable() {

--- a/sfall/ScriptOps/MiscOps.hpp
+++ b/sfall/ScriptOps/MiscOps.hpp
@@ -1684,14 +1684,14 @@ static void sf_set_ini_setting() {
 	int result = -1;
 
 	const char* iniString = opHandler.arg(0).asString();
-	const char* sValue = opHandler.arg(1).asString();
+	const ScriptValue &argVal = opHandler.arg(1);
 
 	IniStrBuffer[0] = 0;
-	if (strlen(sValue) == 0)
-		_itoa_s(opHandler.arg(1).asInt(), IniStrBuffer, 10);
+	if (argVal.isInt())
+		_itoa_s(argVal.asInt(), IniStrBuffer, 10);
 	else
-		strcpy(IniStrBuffer, sValue);
-
+		strcpy(IniStrBuffer, argVal.asString());
+		
 	const char* key = strstr(iniString, "|");
 	if (!key) goto error;
 

--- a/sfall/ScriptOps/MiscOps.hpp
+++ b/sfall/ScriptOps/MiscOps.hpp
@@ -694,28 +694,39 @@ end:
 	}
 }
 
-static char IniStrBuffer[128];
-static DWORD _stdcall GetIniSetting2(const char* c, DWORD string) {
-	const char* key = strstr(c, "|");
+static int ParseIniSetting(const char* iniString, const char* &key, char section[], char file[]) {
+	key = strstr(iniString, "|");
 	if (!key) return -1;
-	DWORD filelen = (DWORD)key - (DWORD)c;
-	if (filelen >= 64) return -1;
-	key = strstr(key + 1, "|");
-	if (!key) return -1;
-	DWORD seclen = (DWORD)key - ((DWORD)c + filelen + 1);
-	if (seclen > 32) return -1;
 
-	char file[67];
+	DWORD filelen = (DWORD)key - (DWORD)iniString;
+	if (filelen >= 64)  return -1;
+
+	key = strstr(key + 1, "|");
+	if (!key)  return -1;
+
+	DWORD seclen = (DWORD)key - ((DWORD)iniString + filelen + 1);
+	if (seclen > 32)  return -1;
+
 	file[0] = '.';
 	file[1] = '\\';
-	memcpy(&file[2], c, filelen);
+	memcpy(&file[2], iniString, filelen);
 	file[filelen + 2] = 0;
 
-	char section[33];
-	memcpy(section, &c[filelen + 1], seclen);
+	memcpy(section, &iniString[filelen + 1], seclen);
 	section[seclen] = 0;
 
 	key++;
+	return 1;
+}
+
+static char IniStrBuffer[128];
+static DWORD _stdcall GetIniSetting2(const char* c, DWORD string) {
+	const char* key;
+	char section[33], file[67];
+	
+	if (ParseIniSetting(c, key, section, file) < 0) {
+		return -1;
+	}
 	if (string) {
 		IniStrBuffer[0] = 0;
 		GetPrivateProfileStringA(section, key, "", IniStrBuffer, 128, file);
@@ -1681,48 +1692,27 @@ static void sf_exec_map_update_scripts() {
 }
 
 static void sf_set_ini_setting() {
-	int result = -1;
-
 	const char* iniString = opHandler.arg(0).asString();
 	const ScriptValue &argVal = opHandler.arg(1);
 
-	IniStrBuffer[0] = 0;
 	if (argVal.isInt())
 		_itoa_s(argVal.asInt(), IniStrBuffer, 10);
 	else
 		strcpy(IniStrBuffer, argVal.asString());
-		
-	const char* key = strstr(iniString, "|");
-	if (!key) goto error;
 
-	DWORD filelen = (DWORD)key - (DWORD)iniString;
-	if (filelen >= 64) goto error;
+	const char* key;
+	char section[33], file[67];
+	int result = ParseIniSetting(iniString, key, section, file);
+	if (result > 0) {
+		result = WritePrivateProfileString(section, key, IniStrBuffer, file);
+	}
 
-	key = strstr(key + 1, "|");
-	if (!key) goto error;
-
-	DWORD seclen = (DWORD)key - ((DWORD)iniString + filelen + 1);
-	if (seclen > 32) goto error;
-
-	char file[67];
-	file[0] = '.';
-	file[1] = '\\';
-	memcpy(&file[2], iniString, filelen);
-	file[filelen + 2] = 0;
-
-	char section[33];
-	memcpy(section, &iniString[filelen + 1], seclen);
-	section[seclen] = 0;
-
-	result = WritePrivateProfileString(section, ++key, IniStrBuffer, file);
-
-error:
 	switch (result) {
 	case 0:
 		opHandler.printOpcodeError("set_ini_setting() - value save error.");
 		break;
 	case -1:
-		opHandler.printOpcodeError("set_ini_setting() - invalid arguments.");
+		opHandler.printOpcodeError("set_ini_setting() - invalid setting argument.");
 		break;
 	}
 }


### PR DESCRIPTION
`void sfall_func2("set_ini_setting", string setting, int/string value)`
- setting - The string with arguments for accessing the file, section and key, separated by character '|' (e.g. "myini.ini|mysec|var").
- value - The set value for the key, can be either a string value or an integer value.