### PR TITLE
Fixed function "get_attack_type" and new function "attack_is_aimed".

### DIFF
--- a/artifacts/scripting/headers/sfall.h
+++ b/artifacts/scripting/headers/sfall.h
@@ -210,6 +210,7 @@
 #define party_member_list_all           party_member_list(1)
 
 
+#define attack_is_aimed                       sfall_func0("attack_is_aimed")
 #define car_gas_amount                        sfall_func0("car_gas_amount")
 #define critter_inven_obj2(obj, type)         sfall_func2("critter_inven_obj2", obj, type)
 #define display_stats                         sfall_func0("display_stats")

--- a/sfall/Modules/Scripting/Handlers/Metarule.cpp
+++ b/sfall/Modules/Scripting/Handlers/Metarule.cpp
@@ -77,6 +77,7 @@ static const SfallMetarule* currentMetarule;
 		- arg1, arg2, ... - argument types for automatic validation
 */
 static const SfallMetarule metarules[] = {
+	{"attack_is_aimed", sf_attack_is_aimed, 0, 0},
 	{"car_gas_amount", sf_car_gas_amount, 0, 0},
 	{"critter_inven_obj2", sf_critter_inven_obj2, 2, 2, {ARG_OBJECT, ARG_INT}},
 	{"display_stats", sf_display_stats, 0, 0},

--- a/sfall/Modules/Scripting/Handlers/Misc.cpp
+++ b/sfall/Modules/Scripting/Handlers/Misc.cpp
@@ -1746,7 +1746,7 @@ void sf_attack_is_aimed(OpcodeContext& ctx) {
 		mov result, eax;
 		mov is_secondary, edx;
 	}
-	ctx.setReturn((result != -1) ? is_secondary : -1);
+	ctx.setReturn((result != -1) ? is_secondary : 0);
 }
 
 void sf_sneak_success(OpcodeContext& ctx) {

--- a/sfall/Modules/Scripting/Handlers/Misc.cpp
+++ b/sfall/Modules/Scripting/Handlers/Misc.cpp
@@ -1408,11 +1408,19 @@ void __declspec(naked) op_get_attack_type() {
 		push ecx;
 		push eax;
 		call intf_attack_type;
+		mov edx, ecx; // hit_mode
 		test eax, eax;
 		jz skip;
-		mov ecx, eax; // result = -1
+		cmp ds:[FO_VAR_interfaceWindow], eax;
+		jz end;
+		mov ecx, ds:[FO_VAR_itemCurrentItem];     // 0 - left, 1 - right
+		imul edx, ecx, 0x18;
+		cmp ds:[FO_VAR_itemButtonItems+5+edx], 1; // .itsWeapon
+		jnz end;
+		lea eax, [ecx+6];
+end:
+		mov edx, eax; // result
 skip:
-		mov edx, ecx; // hit_mode
 		pop ecx;
 		mov eax, ecx;
 		call fo::funcoffs::interpretPushLong_;

--- a/sfall/Modules/Scripting/Handlers/Misc.h
+++ b/sfall/Modules/Scripting/Handlers/Misc.h
@@ -29,6 +29,8 @@ namespace script
 
 class OpcodeContext;
 
+void _stdcall intf_attack_type();
+
 // TODO: rewrite all op_* functions using OpcodeContext
 
 void __declspec() op_set_dm_model();
@@ -151,9 +153,11 @@ void __declspec() op_gdialog_get_barter_mod();
 
 void __declspec() op_set_inven_ap_cost();
 
-void sf_sneak_success(OpcodeContext& ctx);
+void sf_attack_is_aimed(OpcodeContext&);
 
-void sf_tile_light(OpcodeContext& ctx);
+void sf_sneak_success(OpcodeContext&);
+
+void sf_tile_light(OpcodeContext&);
 
 void sf_exec_map_update_scripts(OpcodeContext&);
 


### PR DESCRIPTION
`attack_is_aimed` - Returns true(1), if the aimed attack mode is selected, otherwise 0.

Fix broken function for v3.8
```
static void __declspec(naked) get_attack_type() {
	__asm {
		push edx;
		push ecx;
		push eax;
		sub esp, 8;
		lea edx, [esp];
		lea eax, [esp+4];
		call intface_get_attack_;
		add esp, 4;	// is_secondary
		test eax, eax;
		jz jskip;
		add esp, 4;
                // get reload
		cmp ds:[_interfaceWindow], eax;
		jz jend;
		mov ecx, ds:[_itemCurrentItem];  // 0 - left, 1 - right
		imul edx, ecx, 0x18;
		cmp ds:[_itemButtonItems+5+edx], 1; // .itsWeapon
		jnz jend;
		lea eax, [ecx+6];
		jmp jend;
jskip:
		pop eax;	// hit_mode
jend:
		pop ecx;
		_RET_VAL_INT(ecx);
		pop ecx;
		pop edx;
		retn;
	}
}
```
`const DWORD intface_get_attack_ = 0x45EF6C;` - for FalloutEngine.cpp