### PR TITLE
Added an additional mode to 'metarule2_explosions' function.

### DIFF
--- a/artifacts/scripting/headers/sfall.h
+++ b/artifacts/scripting/headers/sfall.h
@@ -137,6 +137,7 @@
 #define set_attack_explosion_radius(x)        metarule2_explosions(3, x, 0)
 #define set_attack_is_explosion(x)            metarule2_explosions(4, x, 0)
 #define set_attack_is_explosion_fire          set_attack_is_explosion(DMG_fire)
+#define set_explosion_radius(grenade, rocket) metarule2_explosions(5, grenade, rocket)
 
 
 #define GAME_MSG_COMBAT      (0)

--- a/sfall/Modules/Scripting/Handlers/Anims.cpp
+++ b/sfall/Modules/Scripting/Handlers/Anims.cpp
@@ -108,10 +108,12 @@ void sf_reg_anim_turn_towards(OpcodeContext& ctx) {
 
 void sf_explosions_metarule(OpcodeContext& ctx) {
 	int mode = ctx.arg(0).asInt(),
-		arg1 = ctx.arg(1).asInt(),
-		arg2 = ctx.arg(2).asInt();
-
-	ctx.setReturn(ExplosionsMetaruleFunc(mode, arg1, arg2));
+		result = ExplosionsMetaruleFunc(mode, ctx.arg(1).asInt(), ctx.arg(2).asInt());
+	
+	if (result == -1) {
+		ctx.printOpcodeError("ExplosionsMetalure() - mode (%d) is not supported for the function.", mode);
+	}
+	ctx.setReturn(result);
 }
 
 }


### PR DESCRIPTION
Sets a permanent (reset to default after loading the game) radius of the explosion for rockets or grenades.

`LoadGameHook::OnGameReset() += ResetExplosionRadius;`
It is necessary to check the reset values, I'm not sure that it is code working)