### PR TITLE
Adding to the function get_mouse_buttons return of pressing middle mouse button.

### DIFF
--- a/sfall/InputFuncs.cpp
+++ b/sfall/InputFuncs.cpp
@@ -36,7 +36,7 @@ static DWORD wheelMod;
 
 static bool reverseMouse;
 
-static bool middleMouseDown;
+bool middleMouseDown;
 static DWORD middleMouseKey;
 
 static bool backgroundKeyboard;

--- a/sfall/InputFuncs.h
+++ b/sfall/InputFuncs.h
@@ -26,6 +26,7 @@ namespace sfall
 {
 
 extern bool useScrollWheel;
+extern bool middleMouseDown;
 
 void SetMDown(bool down, bool right);
 void SetMPos(int x, int y);

--- a/sfall/Modules/Scripting/Handlers/Interface.cpp
+++ b/sfall/Modules/Scripting/Handlers/Interface.cpp
@@ -114,20 +114,13 @@ void __declspec(naked) op_get_mouse_y() {
 	}
 }
 
-void __declspec(naked) op_get_mouse_buttons() {
-	__asm {
-		push ecx;
-		push edx;
-		mov ecx, eax;
-		mov edx, ds:[FO_VAR_last_buttons];
-		call fo::funcoffs::interpretPushLong_;
-		mov eax, ecx;
-		mov edx, VAR_TYPE_INT;
-		call fo::funcoffs::interpretPushShort_
-		pop edx;
-		pop ecx;
-		retn;
+#define MOUSE_MIDDLE_BTN        (4)
+void sf_get_mouse_buttons(OpcodeContext& ctx) {
+	DWORD button = fo::var::last_buttons;
+	if (button == 0 && middleMouseDown) {
+		button = MOUSE_MIDDLE_BTN;
 	}
+	ctx.setReturn(button);
 }
 
 void __declspec(naked) op_get_window_under_mouse() {

--- a/sfall/Modules/Scripting/Handlers/Interface.h
+++ b/sfall/Modules/Scripting/Handlers/Interface.h
@@ -38,8 +38,8 @@ void __declspec() op_get_mouse_x();
 //Return mouse y position
 void __declspec() op_get_mouse_y();
 
-//Return pressed mouse button (1=left, 2=right, 3=left+right)
-void __declspec() op_get_mouse_buttons();
+//Return pressed mouse button (1=left, 2=right, 3=left+right, 4=middle)
+void sf_get_mouse_buttons(OpcodeContext&);
 
 //Return the window number under the mous
 void __declspec() op_get_window_under_mouse();

--- a/sfall/Modules/Scripting/Opcodes.cpp
+++ b/sfall/Modules/Scripting/Opcodes.cpp
@@ -83,12 +83,13 @@ static SfallOpcodeInfo opcodeInfoArray[] = {
 	{0x218, "set_weapon_ammo_pid", sf_set_weapon_ammo_pid, 2, false, {ARG_OBJECT, ARG_INT}},
 	{0x219, "get_weapon_ammo_count", sf_get_weapon_ammo_count, 1, true, {ARG_OBJECT}},
 	{0x21a, "set_weapon_ammo_count", sf_set_weapon_ammo_count, 2, false, {ARG_OBJECT, ARG_INT}},
+	{0x21e, "get_mouse_buttons", sf_get_mouse_buttons, 0, true},
 
 	{0x22d, "create_array", sf_create_array, 2, true, {ARG_INT, ARG_INT}},
 	{0x22e, "set_array", sf_set_array, 3, false, {ARG_OBJECT, ARG_ANY, ARG_ANY}},
 	{0x22f, "get_array", sf_get_array, 2, true, {ARG_ANY, ARG_ANY}}, // can also be used on strings
 	{0x230, "free_array", sf_free_array, 1, false, {ARG_OBJECT}},
-	{0x231, "len_array", sf_len_array, 1, true, {ARG_OBJECT}},
+	{0x231, "len_array", sf_len_array, 1, true, {ARG_INT}},
 	{0x232, "resize_array", sf_resize_array, 2, false, {ARG_OBJECT, ARG_INT}},
 	{0x233, "temp_array", sf_temp_array, 2, true, {ARG_INT, ARG_INT}},
 	{0x234, "fix_array", sf_fix_array, 1, false, {ARG_INT}},
@@ -375,7 +376,6 @@ void InitNewOpcodes() {
 	}
 	opcodes[0x21c] = op_get_mouse_x;
 	opcodes[0x21d] = op_get_mouse_y;
-	opcodes[0x21e] = op_get_mouse_buttons;
 	opcodes[0x21f] = op_get_window_under_mouse;
 	opcodes[0x220] = op_get_screen_width;
 	opcodes[0x221] = op_get_screen_height;


### PR DESCRIPTION
Issue: #114 #128

Implementation for 3.8 (if there is a desire to fix it).
```
//Return pressed mouse button (1=left, 2=right, 3=left+right, 4=middle)
static void __declspec(naked) get_mouse_buttons() {
   __asm {
	  push ecx;
	  push edx;
	  mov edx, ds:[_last_buttons];
	  test edx, edx;
	  jnz skip;
	  movzx ecx, MiddleMouseDown;
	  test ecx, ecx;
	  jz skip;
	  mov edx, 4; 
skip:
	  mov ecx, eax;
	  call interpretPushLong_;
	  mov eax, ecx;
	  mov edx, VAR_TYPE_INT;
	  call interpretPushShort_
	  pop edx;
	  pop ecx;
	  retn;
   }
}
```