### PR TITLE
VS 2017 support

### DIFF
--- a/sfall/Modules/Message.h
+++ b/sfall/Modules/Message.h
@@ -28,7 +28,7 @@
 namespace sfall
 {
 
-typedef std::tr1::unordered_map<int, std::unique_ptr<fo::MessageList>> ExtraGameMessageListsMap;
+typedef std::unordered_map<int, std::unique_ptr<fo::MessageList>> ExtraGameMessageListsMap;
 extern ExtraGameMessageListsMap gExtraGameMsgLists;
 
 class Message : public Module {

--- a/sfall/Modules/ScriptExtender.cpp
+++ b/sfall/Modules/ScriptExtender.cpp
@@ -80,7 +80,7 @@ static SfallProgsMap sfallProgsMap;
 // a map scriptPtr => self_obj  to override self_obj for all script types using set_self
 std::unordered_map<fo::Program*, fo::GameObject*> selfOverrideMap;
 
-typedef std::tr1::unordered_map<std::string, ExportedVar> ExportedVarsMap;
+typedef std::unordered_map<std::string, ExportedVar> ExportedVarsMap;
 static ExportedVarsMap globalExportedVars;
 DWORD isGlobalScriptLoading = 0;
 DWORD modifiedIni;

--- a/sfall/Modules/Scripting/Arrays.h
+++ b/sfall/Modules/Scripting/Arrays.h
@@ -83,7 +83,7 @@ struct sArrayVarOld
 
 #define ARRAYFLAG_ASSOC		(1) // is map
 
-typedef std::tr1::unordered_map<sArrayElement, DWORD, sArrayElement_HashFunc, sArrayElement_EqualFunc> ArrayKeysMap;
+typedef std::unordered_map<sArrayElement, DWORD, sArrayElement_HashFunc, sArrayElement_EqualFunc> ArrayKeysMap;
 
 /**
 	This class represents sfall array
@@ -128,7 +128,7 @@ public:
 };
 
 // arrays map: arrayId => arrayVar
-typedef std::tr1::unordered_map<DWORD, sArrayVar> ArraysMap;
+typedef std::unordered_map<DWORD, sArrayVar> ArraysMap;
 extern ArraysMap arrays;
 typedef ArraysMap::const_iterator array_citr;
 typedef ArraysMap::iterator array_itr;

--- a/sfall/Modules/Scripting/Handlers/Metarule.cpp
+++ b/sfall/Modules/Scripting/Handlers/Metarule.cpp
@@ -57,7 +57,7 @@ struct SfallMetarule {
 	OpcodeArgumentType argValidation[OP_MAX_ARGUMENTS];
 };
 
-typedef std::tr1::unordered_map<std::string, const SfallMetarule*> MetaruleTableType;
+typedef std::unordered_map<std::string, const SfallMetarule*> MetaruleTableType;
 
 static MetaruleTableType metaruleTable;
 

--- a/sfall/Modules/Scripting/Opcodes.cpp
+++ b/sfall/Modules/Scripting/Opcodes.cpp
@@ -51,7 +51,7 @@ static const short opcodeCount = 0x300;
 // Other half is filled by sfall here.
 static void* opcodes[opcodeCount];
 
-typedef std::tr1::unordered_map<int, const SfallOpcodeInfo*> OpcodeInfoMapType;
+typedef std::unordered_map<int, const SfallOpcodeInfo*> OpcodeInfoMapType;
 
 // Opcode Table. Add additional (sfall) opcodes here.
 // Format: {

--- a/sfall/ddraw.vcxproj
+++ b/sfall/ddraw.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -24,7 +24,7 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>NotSet</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseXP|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
@@ -35,7 +35,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>NotSet</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
Migration to Visual Studio 2017 build tools.

Why? Because VS 2017 is easier to install, takes less disk space and overall works faster than VS 2015. Requirement to install VS 2015 just to build sfall is too harsh for newcomers :)