### PR TITLE
Keep selected attack mode for weapon

### DIFF
--- a/sfall/FalloutEngine/Enums.h
+++ b/sfall/FalloutEngine/Enums.h
@@ -420,8 +420,8 @@ enum Trait : long
 enum class ScenerySubType : long
 {
 	DOOR = 0,
-	STAIRS = 1, 
-	ELEVATOR = 2, 
+	STAIRS = 1,
+	ELEVATOR = 2,
 	LADDER_BOTTOM = 3,
 	LADDER_TOP = 4,
 	GENERIC = 5
@@ -577,6 +577,38 @@ enum ItemType : long
 	item_type_ammo = 4,
 	item_type_misc_item = 5,
 	item_type_key = 6,
+};
+
+// Inventory Equates
+enum InvenType : long
+{
+	INVEN_TYPE_WORN = 0,
+	INVEN_TYPE_RIGHT_HAND = 1,
+	INVEN_TYPE_LEFT_HAND = 2,
+};
+
+enum AttackType : long
+{
+	ATKTYPE_LWEAPON_PRIMARY   = 0,
+	ATKTYPE_LWEAPON_SECONDARY = 1,
+	ATKTYPE_RWEAPON_PRIMARY   = 2,
+	ATKTYPE_RWEAPON_SECONDARY = 3,
+	ATKTYPE_PUNCH             = 4,
+	ATKTYPE_KICK              = 5,
+	ATKTYPE_LWEAPON_RELOAD    = 6,
+	ATKTYPE_RWEAPON_RELOAD    = 7,
+	ATKTYPE_STRONGPUNCH       = 8,
+	ATKTYPE_HAMMERPUNCH       = 9,
+	ATKTYPE_HAYMAKER          = 10,
+	ATKTYPE_JAB               = 11,
+	ATKTYPE_PALMSTRIKE        = 12,
+	ATKTYPE_PIERCINGSTRIKE    = 13,
+	ATKTYPE_STRONGKICK        = 14,
+	ATKTYPE_SNAPKICK          = 15,
+	ATKTYPE_POWERKICK         = 16,
+	ATKTYPE_HIPKICK           = 17,
+	ATKTYPE_HOOKKICK          = 18,
+	ATKTYPE_PIERCINGKICK      = 19
 };
 
 #define OBJFLAG_CAN_WEAR_ITEMS (0xf000000)

--- a/sfall/Modules/MiscPatches.cpp
+++ b/sfall/Modules/MiscPatches.cpp
@@ -368,8 +368,11 @@ static void __declspec(naked) objCanSeeObj_ShootThru_Fix() {//(EAX *objStruct, E
 static DWORD __fastcall GetWeaponSlotMode(DWORD itemPtr, DWORD mode) {
 	int slot = (mode > 0) ? 1 : 0;
 	auto itemButton = fo::var::itemButtonItems;
-	if ((DWORD)itemButton.vals[slot].item == itemPtr && (DWORD)itemButton.vals[slot].mode == 3) {
-		mode++;
+	if ((DWORD)itemButton[slot].item == itemPtr) {
+		int slotMode = itemButton[slot].mode;
+		if (slotMode == 3 || slotMode == 4) {
+			mode++;
+		}
 	}
 	return mode;
 }
@@ -384,6 +387,69 @@ static void __declspec(naked) display_stats_hook() {
 		pop ecx;
 		pop eax;
 		jmp fo::funcoffs::item_w_range_;
+	}
+}
+
+static void __fastcall SwapHandSlots(fo::GameObject* item, DWORD* toSlot) {
+
+	if (fo::GetItemType(item) != fo::item_type_weapon && *toSlot
+		 && fo::GetItemType((fo::GameObject*)*toSlot) != fo::item_type_weapon) {
+		return;
+	}
+
+	DWORD* leftSlot = (DWORD*)FO_VAR_itemButtonItems;
+	DWORD* rightSlot = leftSlot + 6;
+
+	if (*toSlot == 0) { //copy to slot
+		DWORD* slot;
+		fo::ItemButtonItem item[1];
+		if ((int)toSlot == FO_VAR_i_lhand) {
+			memcpy(item, rightSlot, 0x14);
+			item[0].primaryAttack   = fo::AttackType::ATKTYPE_LWEAPON_PRIMARY;
+			item[0].secondaryAttack = fo::AttackType::ATKTYPE_LWEAPON_SECONDARY;
+			slot = leftSlot;// Rslot > Lslot;
+		} else {
+			memcpy(item, leftSlot, 0x14);
+			item[0].primaryAttack   = fo::AttackType::ATKTYPE_RWEAPON_PRIMARY;
+			item[0].secondaryAttack = fo::AttackType::ATKTYPE_RWEAPON_SECONDARY;
+			slot = rightSlot; // Lslot > Rslot;
+		}
+		memcpy(slot, item, 0x14);
+	} else { // swap slot
+		fo::ItemButtonItem swapLBuf[1];
+		fo::ItemButtonItem swapRBuf[1];
+
+		memcpy(swapLBuf, leftSlot,  0x14);
+		memcpy(swapRBuf, rightSlot, 0x14);
+
+		swapLBuf[0].primaryAttack   = fo::AttackType::ATKTYPE_RWEAPON_PRIMARY;
+		swapLBuf[0].secondaryAttack = fo::AttackType::ATKTYPE_RWEAPON_SECONDARY;
+		swapRBuf[0].primaryAttack   = fo::AttackType::ATKTYPE_LWEAPON_PRIMARY;
+		swapRBuf[0].secondaryAttack = fo::AttackType::ATKTYPE_LWEAPON_SECONDARY;
+
+		memcpy(leftSlot,  swapRBuf, 0x14); // buf Rslot > Lslot;
+		memcpy(rightSlot, swapLBuf, 0x14); // buf Lslot > Rslot;
+	}
+}
+
+static void __declspec(naked) switch_hand_hack() {
+	__asm {
+		pushfd;
+		test ebx, ebx;
+		jz skip;
+		cmp ebx, edx;
+		jz skip;
+		push ecx;
+		mov ecx, eax;
+		call SwapHandSlots;
+		pop ecx;
+skip:
+		popfd;
+		jz end;
+		retn;
+end:
+		mov dword ptr[esp], 0x4715B7;
+		retn;
 	}
 }
 
@@ -785,6 +851,15 @@ void DisplaySecondWeaponRangePatch() {
 	}
 }
 
+void KeepWeaponSelectModePatch() {
+	if (GetConfigInt("Misc", "KeepWeaponSelectMode", 1)) {
+		dlog("Applying keep weapon select mode patch.", DL_INIT);
+		MakeCall(0x4714EC, switch_hand_hack);
+		SafeWrite8(0x4714F1, 0x90);
+		dlogr(" Done", DL_INIT);
+	}
+}
+
 void MiscPatches::init() {
 	mapName[64] = 0;
 	if (GetConfigString("Misc", "StartingMap", "", mapName, 64)) {
@@ -856,7 +931,9 @@ void MiscPatches::init() {
 	NumbersInDialoguePatch();
 	PipboyAvailableAtStartPatch();
 	DisableHorriganPatch();
+
 	DisplaySecondWeaponRangePatch();
+	KeepWeaponSelectModePatch();
 }
 
 void MiscPatches::exit() {


### PR DESCRIPTION
Option to keep the selected attack mode for the weapon when the weapon moves to another slot of the hand.
And a small fix for the option of displaying a range of weapons for the second mode.