### PR TITLE
Added option for loading alternative dialogue message files.

### DIFF
--- a/sfall/FalloutEngine/EngineUtils.cpp
+++ b/sfall/FalloutEngine/EngineUtils.cpp
@@ -103,6 +103,10 @@ GameObject* GetActiveItem() {
 	return fo::var::itemButtonItems[fo::var::itemCurrentItem].item;
 }
 
+bool HeroIsFemale() {
+	return (fo::func::stat_level(fo::var::obj_dude, fo::Stat::STAT_gender) == fo::Gender::GENDER_FEMALE);
+}
+
 //---------------------------------------------------------
 //print text to surface
 void PrintText(char *DisplayText, BYTE ColourIndex, DWORD Xpos, DWORD Ypos, DWORD TxtWidth, DWORD ToWidth, BYTE *ToSurface) {

--- a/sfall/FalloutEngine/EngineUtils.h
+++ b/sfall/FalloutEngine/EngineUtils.h
@@ -58,6 +58,8 @@ long& GetActiveItemMode();
 
 GameObject* GetActiveItem();
 
+bool HeroIsFemale();
+
 // Print text to surface
 void PrintText(char *displayText, BYTE colorIndex, DWORD x, DWORD y, DWORD textWidth, DWORD destWidth, BYTE *surface);
 // gets the height of the currently selected font

--- a/sfall/FalloutEngine/VariableOffsets.h
+++ b/sfall/FalloutEngine/VariableOffsets.h
@@ -5,6 +5,7 @@
 // To add another variable, first add FO_VAR_* constant with it's address, then add it in Varaibles_def.h
 
 // PLEASE USE THOSE IN ASM BLOCKS!
+#define FO_VAR_aDialogS_msg               0x50DBE8
 #define FO_VAR_aiInfoList                 0x510948
 #define FO_VAR_ambient_light              0x51923C
 #define FO_VAR_anim_set                   0x54CC14

--- a/sfall/Modules/LoadGameHook.cpp
+++ b/sfall/Modules/LoadGameHook.cpp
@@ -73,6 +73,10 @@ DWORD InCombat() {
 	return (inLoop & COMBAT) ? 1 : 0;
 }
 
+DWORD InDialog() {
+	return (inLoop & DIALOG) ? 1 : 0;
+}
+
 DWORD GetLoopFlags() {
 	return inLoop;
 }

--- a/sfall/Modules/LoadGameHook.h
+++ b/sfall/Modules/LoadGameHook.h
@@ -55,6 +55,8 @@ DWORD InWorldMap();
 
 DWORD InCombat();
 
+DWORD InDialog();
+
 enum LoopFlag : unsigned long {
 	WORLDMAP    = 1 << 0, // 0x1
 	LOCALMAP    = 1 << 1, // 0x2 No point hooking this: would always be 1 at any point at which scripts are running

--- a/sfall/Modules/LoadOrder.cpp
+++ b/sfall/Modules/LoadOrder.cpp
@@ -19,11 +19,54 @@
 #include "..\main.h"
 #include "..\FalloutEngine\Fallout2.h"
 #include "..\Logging.h"
+#include "LoadGameHook.h"
 
 #include "LoadOrder.h"
 
 namespace sfall
 {
+
+static const char* msgFemaleFolder = "dialog_female\\%s.msg";
+static bool isFemale    = false;
+static bool femaleCheck = false;  // flag for check female dialog file
+static DWORD format;
+
+static void CheckPlayerGender() {
+	isFemale = fo::HeroIsFemale();
+}
+
+static const DWORD scr_get_dialog_msg_file_Back = 0x4A6BD2;
+static void __declspec(naked) scr_get_dialog_msg_file_hack1() {
+	__asm {
+		cmp  isFemale, 1;
+		jnz  default;
+		mov  format, eax;
+		mov  femaleCheck, 1;
+		push msgFemaleFolder;
+		jmp  scr_get_dialog_msg_file_Back;
+default:
+		push FO_VAR_aDialogS_msg;            // default "dialog\%s.msg"
+		jmp  scr_get_dialog_msg_file_Back;
+	}
+}
+
+static void __declspec(naked) scr_get_dialog_msg_file_hack2() {
+	__asm {
+		cmp  eax, 1;          // checking existence of msg file
+		mov  eax, 0x4A6C0E;
+		jz   exist;
+		cmp  femaleCheck, 1;
+		jnz  error;           // no exist default msg file
+		push format;
+		push FO_VAR_aDialogS_msg;          // default "dialog\%s.msg"
+		mov  femaleCheck, 0;               // reset flag
+		jmp  scr_get_dialog_msg_file_Back; // check default msg file
+error:
+		mov  eax, 0x4A6BFA;   // jump to Error
+exist:
+		jmp  eax;
+	}
+}
 
 static void __declspec(naked) removeDatabase() {
 	__asm {
@@ -100,6 +143,14 @@ void LoadOrder::init() {
 		HookCall(0x44436D, &game_init_databases_hook);
 		SafeWrite8(0x4DFAEC, 0x1D); // error correction
 		dlogr(" Done", DL_INIT);
+	}
+
+	if (GetConfigInt("Misc", "DialogFemaleMsgFile", 0)) {
+		dlog("Applying dialog files load order patch.", DL_INIT);
+		MakeJump(0x4A6BCD, scr_get_dialog_msg_file_hack1);
+		MakeJump(0x4A6BF5, scr_get_dialog_msg_file_hack2);
+		dlogr(" Done", DL_INIT);
+		LoadGameHook::OnAfterGameStarted() += CheckPlayerGender;
 	}
 }
 


### PR DESCRIPTION
To the ExtraGameMsgFileList option, added ability to directly specify the number order for the message file. Example variants:
```
ExtraGameMsgFileList = MsgFile0:0x64, MsgFile1:101, MsgFile2 < valid number order (MsgFile2 will have a number 102)
ExtraGameMsgFileList = MsgFile0, MsgFile1, MsgFile2:0xFF < valid number order
ExtraGameMsgFileList = MsgFile0, MsgFile1, MsgFile2:0x1  < invalid number order (conflict with the number MsgFile1)
```

For the DialogFemaleMsgFile option, you can select a different name.