### PR TITLE
Hot fix CheckWeaponAmmoCost.

### DIFF
--- a/sfall/Modules/HookScripts.cpp
+++ b/sfall/Modules/HookScripts.cpp
@@ -154,6 +154,10 @@ void HookScripts::InjectingHook(int hookId) {
 	}
 }
 
+bool HookScripts::IsInjectHook(int hookId) {
+	return injectHooks[hookId].isInject;
+}
+
 void _stdcall RegisterHook(fo::Program* script, int id, int procNum) {
 	if (id >= numHooks) return;
 	for (std::vector<HookScript>::iterator it = hooks[id].begin(); it != hooks[id].end(); ++it) {

--- a/sfall/Modules/HookScripts.h
+++ b/sfall/Modules/HookScripts.h
@@ -71,6 +71,7 @@ public:
 	void init();
 
 	static void InjectingHook(int hookId);
+	static bool IsInjectHook(int hookId);
 	static bool injectAllHooks;
 
 	static void GameModeChangeHook(DWORD exit);


### PR DESCRIPTION
There was a division by 0, which caused an error when checking the count of ammo.