### PR TITLE
Allow loading custom .dll file(s)

### DIFF
--- a/artifacts/ddraw.ini
+++ b/artifacts/ddraw.ini
@@ -791,6 +791,10 @@ SkipSizeCheck=0
 ;Does not require sfall debugging mode
 ;ExtraCRC=0x00000000,0x00000000
 
+;Allows loading custom .dll file(s) after sfall initialization
+;To load more than one library, separate filenames with comma
+;LoadDll=filename.dll
+
 ;Set to 1 to stop Fallout from deleting non read-only protos at startup
 ;Has pretty nasty side effects when saving/reloading, so don't use for regular gameplay
 DontDeleteProtos=0

--- a/sfall/Modules/LoadDll.cpp
+++ b/sfall/Modules/LoadDll.cpp
@@ -26,7 +26,7 @@ namespace sfall
 {
 
 void LoadDll::init() {
-	std::vector<std::string> names = GetIniList("Debugging", "LoadDll", "", 512, ',', ddrawIni);
+	std::vector<std::string> names = GetIniList("Main", "LoadDll", "", 512, ',', ddrawIni);
 
 	for (const auto& name : names) {
 		if (name.empty())

--- a/sfall/Modules/LoadDll.cpp
+++ b/sfall/Modules/LoadDll.cpp
@@ -1,0 +1,46 @@
+/*
+ *    sfall
+ *    Copyright (C) 2020  The sfall team
+ *
+ *    This program is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <string>
+#include <vector>
+
+#include "..\main.h"
+#include "LoadDll.h"
+
+namespace sfall
+{
+
+void LoadDll::init() {
+	std::vector<std::string> names = GetIniList("Debugging", "LoadDll", "", 512, ',', ddrawIni);
+
+	for (const auto& name : names) {
+		if (name.empty())
+			continue;
+
+		dlog_f("Loading %s... ", DL_INIT, name.c_str());
+
+		HMODULE dll = LoadLibraryA(name.c_str());
+
+		if (!dll || dll == INVALID_HANDLE_VALUE)
+			dlogr("ERROR", DL_INIT);
+		else
+			dlogr("OK", DL_INIT);
+	}
+}
+
+}

--- a/sfall/Modules/LoadDll.h
+++ b/sfall/Modules/LoadDll.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "Module.h"
+
+namespace sfall
+{
+
+class LoadDll : public Module {
+public:
+	const char* name() { return "LoadDll"; }
+	void init();
+};
+
+}

--- a/sfall/ddraw.vcxproj
+++ b/sfall/ddraw.vcxproj
@@ -376,6 +376,7 @@
     <ClInclude Include="Logging.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="Modules\ExtraSaveSlots.h" />
+    <ClInclude Include="Modules\LoadDll.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="CheckAddress.cpp" />
@@ -464,6 +465,7 @@
     <ClCompile Include="Logging.cpp" />
     <ClCompile Include="Modules\ExtraSaveSlots.cpp" />
     <ClCompile Include="Modules\ScriptShaders.cpp" />
+    <ClCompile Include="Modules\LoadDll.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>

--- a/sfall/ddraw.vcxproj.filters
+++ b/sfall/ddraw.vcxproj.filters
@@ -284,6 +284,9 @@
     <ClInclude Include="Modules\CritterStats.h">
       <Filter>Modules</Filter>
     </ClInclude>
+    <ClInclude Include="Modules\LoadDll.h">
+      <Filter>Modules</Filter>
+    </ClInclude>
     <ClInclude Include="CRC.h" />
     <ClInclude Include="CheckAddress.h" />
   </ItemGroup>
@@ -528,6 +531,9 @@
       <Filter>Modules</Filter>
     </ClCompile>
     <ClCompile Include="Modules\CritterStats.cpp">
+      <Filter>Modules</Filter>
+    </ClCompile>
+    <ClCompile Include="Modules\LoadDll.cpp">
       <Filter>Modules</Filter>
     </ClCompile>
     <ClCompile Include="CRC.cpp" />

--- a/sfall/main.cpp
+++ b/sfall/main.cpp
@@ -34,6 +34,7 @@
 #include "Modules\Credits.h"
 #include "Modules\Criticals.h"
 #include "Modules\CritterStats.h"
+#include "Modules\LoadDll.h"
 #include "Modules\DamageMod.h"
 #include "Modules\DebugEditor.h"
 #include "Modules\Drugs.h"
@@ -210,6 +211,9 @@ static void InitModules() {
 	manager.add<ScriptExtender>();
 
 	manager.add<DebugEditor>();
+
+	// custom libraries should be loaded after applying all changes
+	manager.add<LoadDll>();
 
 	manager.initAll();
 


### PR DESCRIPTION
Filenames are taken from config, and loaded after sfall initialization. `[Debugging]` isn't exactly a perfect place for it, but i couldn't find anything better.