### PR TITLE
Add dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+   interval: "monthly"
+  labels:
+  - "dependencies"


### PR DESCRIPTION
Automagically makes PRs to bump versions of used Actions, just like docs/ updates.
